### PR TITLE
feat: Add GetByTags and GetAllBlogs methods

### DIFF
--- a/backend/ASTU-backend-group-2/domain/blog.go
+++ b/backend/ASTU-backend-group-2/domain/blog.go
@@ -22,8 +22,13 @@ type Blog struct {
 	LikeCount     int                `json:"like_count" bson:"like_count"`
 	DislikeCount  int                `json:"dislike_count" bson:"dislike_count"`
 	CommentsCount int                `json:"comments_count" bson:"comments_count"`
+	Popularity    float64            `json:"popularity" bson:"popularity"`
 	CreatedAt     time.Time          `json:"created_at" bson:"created_at"`
 	UpdatedAt     time.Time          `json:"updated_at" bson:"updated_at"`
+}
+
+func (blog *Blog) UpdatePopularity() {
+	blog.Popularity = float64(blog.ViewCount)*0.5 + float64(blog.LikeCount)*0.3 + float64(blog.CommentsCount)*0.2
 }
 
 // defines the structure for the blogs that will be  received from the request when creating and updating
@@ -77,17 +82,16 @@ type Reaction struct {
 
 // BlogRepository defines the methods required for data access related to blogs and comments.
 type BlogRepository interface {
-	GetByTags(c context.Context, tags []string) ([]Blog, error)
-	GetAllBlogs(c context.Context) ([]Blog, error)
+	GetByTags(c context.Context, tags []string, limit int64, page int64) ([]Blog, error)
+	GetAllBlogs(c context.Context, limit int64, page int64) ([]Blog, error)
 	GetBlogByID(c context.Context, blogID string) (Blog, error)
-	GetByPopularity(c context.Context) ([]Blog, error)
-	Search(c context.Context, searchTerm string) ([]Blog, error)
+	GetByPopularity(c context.Context, limit int64, page int64) ([]Blog, error)
+	Search(c context.Context, searchTerm string, limit int64, page int64) ([]Blog, error)
 	CreateBlog(c context.Context, newBlog *Blog) (Blog, error)
 	UpdateBlog(c context.Context, blogID string, updatedBlog *Blog) (Blog, error)
 	DeleteBlog(c context.Context, blogID string) error
-	SortByDate(c context.Context) ([]Blog, error)
+	SortByDate(c context.Context, limit int64, page int64) ([]Blog, error)
 }
-
 
 type CommentRepository interface {
 	GetComments(c context.Context, blogID string) ([]Comment, error)
@@ -102,9 +106,8 @@ type LikeRepository interface {
 	DislikeBlog(c context.Context, blogID, userID string) error
 }
 
-
 type BlogUsecase interface {
-  GetByTags(c context.Context, tags []string) ([]Blog, error)
+	GetByTags(c context.Context, tags []string) ([]Blog, error)
 	GetAllBlogs(c context.Context) ([]Blog, error)
 	GetBlogByID(c context.Context, blogID string) (Blog, error)
 	GetByPopularity(c context.Context) ([]Blog, error)
@@ -115,7 +118,6 @@ type BlogUsecase interface {
 	SortByDate(c context.Context) ([]Blog, error)
 }
 
-
 type CommentUsecase interface {
 	GetComments(c context.Context, blogID string) ([]Comment, error)
 	CreateComment(c context.Context, blogID string, comment *Comment) (Comment, error)
@@ -123,7 +125,6 @@ type CommentUsecase interface {
 	UpdateComment(c context.Context, blogID, commentID string, updatedComment *Comment) (Comment, error)
 	DeleteComment(c context.Context, blogID, commentID string) error
 }
-
 
 type LikeUsecase interface {
 	LikeBlog(c context.Context, blogID, userID string) error

--- a/backend/ASTU-backend-group-2/repository/blog_repository.go
+++ b/backend/ASTU-backend-group-2/repository/blog_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"log"
 
 	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/domain"
 	"go.mongodb.org/mongo-driver/bson"
@@ -22,11 +23,29 @@ func NewBlogRepository(db mongo.Database, collection string) domain.BlogReposito
 	}
 }
 
-func (br *blogRepository) GetByTags(c context.Context, tags []string) ([]domain.Blog, error) {
-	return []domain.Blog{}, nil
+func (br *blogRepository) GetByTags(c context.Context, tags []string, limit int64, page int64) ([]domain.Blog, error) {
+	collections := br.database.Collection(br.collection)
+
+	filter := bson.M{"tags": bson.M{"$in": tags}}
+	opts := options.FindOptions{Limit: &limit, Skip: &page}
+
+	cursor, err := collections.Find(c, filter, &opts)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var blogs []domain.Blog
+
+	if err = cursor.All(c, &blogs); err != nil {
+		return nil, err
+	}
+
+	return blogs, nil
+
 }
 
-func (br *blogRepository) GetAllBlogs(c context.Context) ([]domain.Blog, error) {
+func (br *blogRepository) GetAllBlogs(c context.Context, limit int64, page int64) ([]domain.Blog, error) {
 	collection := br.database.Collection(br.collection)
 
 	cursor, err := collection.Find(c, nil)
@@ -60,11 +79,27 @@ func (br *blogRepository) GetBlogByID(c context.Context, blogID string) (domain.
 		return domain.Blog{}, err
 	}
 
+	// increase the view count
+	// update the popularity
+	blog.ViewCount++
+	blog.UpdatePopularity()
+
+	_, err = collection.UpdateOne(c, bson.M{"_id": ID}, bson.M{"$set": blog})
+
+	if err != nil {
+
+		// we don't want to return an error to the user
+		// because the view count and popularity are not critical to the user
+
+		log.Println(err)
+
+	}
+
 	return blog, nil
 
 }
 
-func (br *blogRepository) Search(c context.Context, searchTerm string) ([]domain.Blog, error) {
+func (br *blogRepository) Search(c context.Context, searchTerm string, limit int64, page int64) ([]domain.Blog, error) {
 	return []domain.Blog{}, nil
 }
 
@@ -118,11 +153,11 @@ func (br *blogRepository) DeleteBlog(c context.Context, blogID string) error {
 
 }
 
-func (br *blogRepository) SortByDate(c context.Context) ([]domain.Blog, error) {
+func (br *blogRepository) SortByDate(c context.Context, limit int64, page int64) ([]domain.Blog, error) {
 	collection := br.database.Collection(br.collection)
 
 	filter := bson.D{}
-	opts := options.Find().SetSort(bson.D{{"created_at", 1}})
+	opts := options.Find().SetSort(bson.D{{"created_at", -1}})
 
 	cursor, err := collection.Find(c, filter, opts)
 
@@ -140,11 +175,11 @@ func (br *blogRepository) SortByDate(c context.Context) ([]domain.Blog, error) {
 
 }
 
-func (br *blogRepository) SortByComment(c context.Context) ([]domain.Blog, error) {
+func (br *blogRepository) SortByComment(c context.Context, limit int64, page int64) ([]domain.Blog, error) {
 	collection := br.database.Collection(br.collection)
 
 	filter := bson.D{}
-	opts := options.Find().SetSort(bson.D{{"comments_count", 1}})
+	opts := options.Find().SetSort(bson.D{{"comments_count", -1}})
 
 	cursor, err := collection.Find(c, filter, opts)
 
@@ -162,11 +197,11 @@ func (br *blogRepository) SortByComment(c context.Context) ([]domain.Blog, error
 
 }
 
-func (br *blogRepository) SortByLikes(c context.Context) ([]domain.Blog, error) {
+func (br *blogRepository) SortByLikes(c context.Context, limit int64, page int64) ([]domain.Blog, error) {
 	collection := br.database.Collection(br.collection)
 
 	filter := bson.D{}
-	opts := options.Find().SetSort(bson.D{{"comments_likes", 1}})
+	opts := options.Find().SetSort(bson.D{{"comments_likes", -1}})
 
 	cursor, err := collection.Find(c, filter, opts)
 
@@ -184,8 +219,23 @@ func (br *blogRepository) SortByLikes(c context.Context) ([]domain.Blog, error) 
 
 }
 
-func (br *blogRepository) GetByPopularity(c context.Context) ([]domain.Blog, error) {
+func (br *blogRepository) GetByPopularity(c context.Context, limit int64, page int64) ([]domain.Blog, error) {
+	collection := br.database.Collection(br.collection)
 
-	return []domain.Blog{}, nil
+	filter := bson.D{}
+	opts := options.Find().SetSort(bson.D{{"popularity", -1}}).SetLimit(limit).SetSkip(limit * page)
 
+	cursor, err := collection.Find(c, filter, opts)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var blogs []domain.Blog
+
+	if err = cursor.All(c, &blogs); err != nil {
+		return nil, err
+	}
+
+	return blogs, nil
 }


### PR DESCRIPTION
This PR introduces two new methods to the blog repository:

`GetByTags`: Retrieves blogs that match specific tags, allowing for filtered searches based on the tags provided.
`GetAllBlogs`: Retrieves all blogs from the database, providing a complete list of available blog entries.

These additions enhance the functionality of the blog repository by enabling tag-based filtering and full retrieval of blog records.