### PR TITLE
feat: Add route for serving public files

### DIFF
--- a/backend/ASTU-backend-group-2/api/route/files_route.go
+++ b/backend/ASTU-backend-group-2/api/route/files_route.go
@@ -1,0 +1,23 @@
+package route
+
+import (
+	"mime"
+	"path/filepath"
+
+	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/bootstrap"
+	"github.com/gin-gonic/gin"
+)
+
+func NewPublicFileRouter(env *bootstrap.Env, group *gin.RouterGroup) {
+	group.Use(func(c *gin.Context) {
+		if c.Request.Method == "GET" {
+			ext := filepath.Ext(c.Request.URL.Path)
+			mimeType := mime.TypeByExtension(ext)
+			if mimeType != "" {
+				c.Header("Content-Type", mimeType)
+			}
+		}
+		c.Next()
+	})
+	group.Static("/images", "../static/images")
+}

--- a/backend/ASTU-backend-group-2/api/route/route.go
+++ b/backend/ASTU-backend-group-2/api/route/route.go
@@ -20,6 +20,9 @@ func Setup(env *bootstrap.Env, timeout time.Duration, db *mongo.Database, gin *g
 	NewVerificationRouter(env, timeout, db, publicRouter)
 	NewPublicBlogsRouter(env, timeout, db, publicRouter)
 
+	// Static files
+	NewPublicFileRouter(env, publicRouter)
+
 	protectedRouter := gin.Group("")
 	protectedRouter.Use(middleware.JwtAuthMiddleware(env.AccessTokenSecret))
 


### PR DESCRIPTION
The code changes in `files_route.go` add a new route for serving public files. The route is responsible for setting the appropriate Content-Type header based on the file extension. This will improve the handling of static files in the application.