### PR TITLE
Add Resend OTP Endpoint and Improve OTP Generation

### DIFF
--- a/backend/AAiT-backend-group-11/delivery/controller/auth_controller.go
+++ b/backend/AAiT-backend-group-11/delivery/controller/auth_controller.go
@@ -20,7 +20,7 @@ func NewAuthController(authService interfaces.AuthenticationService, passwordRes
 	return &AuthController{
 		authService: authService,
 		passwordResetService: passwordResetService}
-
+	}
 
 func (controller *AuthController) RegisterUser(c *gin.Context) {
 
@@ -138,3 +138,20 @@ func (controller *AuthController) ResetPassword(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Password reset successfully"})
 }
 
+func (controller *AuthController) ResendOtp(c *gin.Context) {
+    var request entities.ResendOTPRequest
+
+    err := c.ShouldBind(&request)
+    if err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        return
+    }
+
+    err = controller.authService.ResendOtp(request)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+        return
+    }
+
+    c.JSON(http.StatusOK, gin.H{"message": "OTP sent successfully"})
+}

--- a/backend/AAiT-backend-group-11/delivery/router/auth_router.go
+++ b/backend/AAiT-backend-group-11/delivery/router/auth_router.go
@@ -39,4 +39,5 @@ func NewAuthRouter(env *bootstrap.Env, db *mongo.Database, group *gin.RouterGrou
 	group.POST("/verify-email", auth_controller.VerifyEmail)
 	group.POST("/forgot-password", auth_controller.RequestPasswordReset)
 	group.POST("/reset-password", auth_controller.ResetPassword)
+	group.POST("/resend-otp", auth_controller.ResendOtp)
 }

--- a/backend/AAiT-backend-group-11/domain/entities/otp.go
+++ b/backend/AAiT-backend-group-11/domain/entities/otp.go
@@ -11,4 +11,9 @@ type OTP struct {
 	Email      string             `bson:"email"`
 	Code       string             `bson:"code"`
 	Expiration time.Time          `bson:"expiration"`
+	IsValid    bool     		  `bson:"is_valid"`
+}
+
+type ResendOTPRequest struct {
+	Email string `json:"email"`
 }

--- a/backend/AAiT-backend-group-11/domain/interfaces/auth.go
+++ b/backend/AAiT-backend-group-11/domain/interfaces/auth.go
@@ -8,5 +8,6 @@ type AuthenticationService interface {
 	Logout(userId string) error
 	RefreshAccessToken(token *entities.RefreshToken) (string,error)
 	VerifyEmail(email string, code string) error
+	ResendOtp(request entities.ResendOTPRequest) error 
 }
 

--- a/backend/AAiT-backend-group-11/infrastructure/middleware/authorization.go
+++ b/backend/AAiT-backend-group-11/infrastructure/middleware/authorization.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"backend-starter-project/domain/interfaces"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"

--- a/backend/AAiT-backend-group-11/repository/otp_repository.go
+++ b/backend/AAiT-backend-group-11/repository/otp_repository.go
@@ -43,7 +43,8 @@ func (o *OtpRepository) InvalidateOtp(otp *entities.OTP) error {
 	collection := o.collection.Database().Collection("otp")
 	ctx := context.Background()
 
-	update := bson.M{}
+	// Update the is_valid field to false
+	update := bson.M{"$set": bson.M{"is_valid": false,},}
 
 	// Define options for the update operation (e.g., to perform an upsert)
 	options := options.Update().SetUpsert(false)

--- a/backend/AAiT-backend-group-11/repository/token_repository.go
+++ b/backend/AAiT-backend-group-11/repository/token_repository.go
@@ -51,7 +51,7 @@ func (tr *tokenRepository) FindRefreshTokenByUserId(user_id string) (*entities.R
 		return nil, result.Err()
 	}
 	var token entities.RefreshToken
-	err := result.Decode(&token)
+	err = result.Decode(&token)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/AAiT-backend-group-11/service/auth_serivce.go
+++ b/backend/AAiT-backend-group-11/service/auth_serivce.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -63,6 +63,8 @@ func (service *authService) RegisterUser(user *entities.User) (*entities.User, e
 		return service.userService.DeleteUser(user.ID.Hex())
 	}
 	
+	rand.Seed(uint64(time.Now().UnixNano()))
+
 	// Generate a random number between 10000 and 99999 (inclusive).
 	randNum := rand.Intn(99999-10000+1) + 10000
 	
@@ -136,7 +138,6 @@ func (service *authService) RegisterUser(user *entities.User) (*entities.User, e
 		if deleteErr != nil {
 			return nil, fmt.Errorf("failed to send email and delete user: %v", deleteErr)
 		}
-		log.Println("sfsfsdfsfsdfs")
 
 		return nil, err
 	}
@@ -210,6 +211,73 @@ func (service *authService) VerifyEmail(email string, code string) error {
 	err = service.otpService.InvalidateOtp(&otp)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (service *authService) ResendOtp(request entities.ResendOTPRequest) error {
+	request.Email = strings.ToLower(request.Email)
+
+	user, err := service.userService.FindUserByEmail(request.Email)
+	if err != nil {
+		return err
+	}
+
+	if user.IsVerified {
+		return fmt.Errorf("failed to resend otp. User account already activated")
+	}
+
+	otp, err := service.otpService.GetOtpByEmail(request.Email)
+	if err != nil {
+		return fmt.Errorf("no OTP requested with the given email")
+	}
+
+	rand.Seed(uint64(time.Now().UnixNano()))
+
+	// Generate a random number between 10000 and 99999 (inclusive).
+	randNum := rand.Intn(99999-10000+1) + 10000
+	
+	// Format the code as a 5-digit string with leading zeros.
+	code := fmt.Sprintf("%05d", randNum)
+
+	// Modify OTP to database
+	otp.Code = code
+	otp.Expiration = time.Now().Add(5 * time.Minute)
+
+	err = service.otpService.SaveOtp(&otp)
+	if err != nil {
+		return fmt.Errorf("failed to save OTP: %v", err.Error())
+	}
+
+	emailContent := `
+		<p>Thank you for signing up with Blog. To verify your account and complete the signup process, please use the following verification code:</p>
+		<h3>` + code + `</h3>
+		<p><strong>This verification code is valid for 5 minutes.</strong> Please enter it on the verification page to proceed.</p>
+		<p>If you did not sign up for a Blog account, please ignore this email.</p>`
+
+	// Create the email subject
+	emailSubject := "Verify Your Email"
+
+	smtpConfig := entities.SMTPConfig{
+		Server:   "smtp.gmail.com:587",
+		Username: "haloitisme0912@gmail.com",
+		Password: "btnb soyo xqpm ooxw",
+	}
+ 
+	// Generate the email body using the template function
+	emailBody := utils.NewEmailService(smtpConfig.Server, smtpConfig.Password, smtpConfig.Username).GenerateEmailTemplate("Blog Account Verification", emailContent)
+ 
+	// Create the email template
+	emailTemplate := entities.EmailTemplate{
+		Subject: emailSubject,
+		Body:    emailBody,
+	}
+ 
+	// Send the email
+	err = utils.NewEmailService(smtpConfig.Server, smtpConfig.Password, smtpConfig.Username).SendEmail(user.Email, emailTemplate.Subject, emailTemplate.Body)
+	if err != nil {
+		return fmt.Errorf("failed to send email: %v", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
Description:

Resend OTP Endpoint: Added an endpoint that allows users to request a new OTP.

OTP Generation: Enhanced OTP generation to ensure a unique OTP is generated every time it is requested.
Invalid Field: Added an invalid field to the OTP model to support the OTP invalidation functionality.

Changes:

New Endpoint:
Created a new API endpoint for resending OTPs to users.

OTP Generation:
Updated the OTP generation logic to guarantee the uniqueness of OTPs on every request.

Invalidation Support:
Added an invalid boolean field to the OTP model to enable invalidating previously generated OTPs.