### PR TITLE
feat: Refactor blog author field to use pointer in entities and usecase

### DIFF
--- a/backend/ASTU-backend-group-2/domain/entities/blog.go
+++ b/backend/ASTU-backend-group-2/domain/entities/blog.go
@@ -16,7 +16,8 @@ const (
 
 type Blog struct {
 	ID            primitive.ObjectID `json:"id,omitempty" bson:"_id"`
-	Author        User               `json:"author,omitempty" bson:"author"`
+	Author        *User              `json:"author,omitempty" bson:"author"`
+	AuthorName    string             `json:"author_name,omitempty" bson:"author_name"`
 	Title         string             `json:"title,omitempty" bson:"title" binding:"required"`
 	Tags          []string           `json:"tags" bson:"tags"`
 	Content       string             `json:"content,omitempty" bson:"content" binding:"required"`
@@ -27,7 +28,6 @@ type Blog struct {
 	Popularity    float64            `json:"popularity,omitempty" bson:"popularity"`
 	CreatedAt     time.Time          `json:"created_at,omitempty" bson:"created_at"`
 	UpdatedAt     time.Time          `json:"updated_at,omitempty" bson:"updated_at"`
-	AuthorName    string             `json:"author_name,omitempty" bson:"author_name"`
 }
 
 func (blog *Blog) UpdatePopularity() {

--- a/backend/ASTU-backend-group-2/domain/entities/user.go
+++ b/backend/ASTU-backend-group-2/domain/entities/user.go
@@ -14,21 +14,21 @@ const (
 )
 
 type User struct {
-	ID         primitive.ObjectID `json:"id" bson:"_id"`
-	FirstName  string             `json:"first_name" bson:"first_name" binding:"required,min=3,max=30"`
-	LastName   string             `json:"last_name" bson:"last_name" binding:"max=30"`
-	Email      string             `json:"email" bson:"email" binding:"required,email"`
-	Active     bool               `json:"is_active" bson:"is_active"`
-	Bio        string             `json:"bio" bson:"bio"`
-	ProfileImg string             `json:"profile_img" bson:"profile_img"`
-	Password   string             `json:"password" bson:"password" binding:"required,min=4,max=30,StrongPassword"`
-	IsOwner    bool               `json:"is_owner" bson:"is_owner"`
-	Role       string             `json:"role" bson:"role"`
-	Tokens     []string           `json:"tokens" bson:"tokens"`
-	VerToken   string             `json:"verify_token" bson:"verfiy_token"`
-	CreatedAt  primitive.DateTime `json:"created_at" bson:"created_at"`
-	UpdatedAt  primitive.DateTime `json:"updated_at" bson:"updated_at"`
-	LastLogin  primitive.DateTime `json:"last_login" bson:"last_login"`
+	ID         primitive.ObjectID `json:"id,omitempty" bson:"_id"`
+	FirstName  string             `json:"first_name,omitempty" bson:"first_name" binding:"required,min=3,max=30"`
+	LastName   string             `json:"last_name,omitempty" bson:"last_name" binding:"max=30"`
+	Email      string             `json:"email,omitempty" bson:"email" binding:"required,email"`
+	Active     bool               `json:"is_active,omitempty" bson:"is_active"`
+	Bio        string             `json:"bio,omitempty" bson:"bio"`
+	ProfileImg string             `json:"profile_img,omitempty" bson:"profile_img"`
+	Password   string             `json:"password,omitempty" bson:"password" binding:"required,min=4,max=30,StrongPassword"`
+	IsOwner    bool               `json:"is_owner,omitempty" bson:"is_owner"`
+	Role       string             `json:"role,omitempty" bson:"role"`
+	Tokens     []string           `json:"tokens,omitempty" bson:"tokens"`
+	VerToken   string             `json:"verify_token,omitempty" bson:"verfiy_token"`
+	CreatedAt  primitive.DateTime `json:"created_at,omitempty" bson:"created_at"`
+	UpdatedAt  primitive.DateTime `json:"updated_at,omitempty" bson:"updated_at"`
+	LastLogin  primitive.DateTime `json:"last_login,omitempty" bson:"last_login"`
 }
 
 // this structure defined for data sent as a response

--- a/backend/ASTU-backend-group-2/repository/blog_repository.go
+++ b/backend/ASTU-backend-group-2/repository/blog_repository.go
@@ -74,27 +74,67 @@ func getFiltered(c context.Context, collection *mongo.Collection, filter bson.M,
 					"$author.last_name",
 				},
 			},
+			"score": bson.M{"$meta": "searchScore"},
 		},
 	}
 
-	search := bson.M{"$match": bson.M{
-		"$text": bson.M{
-			"$search": blogFilter.Search,
-		},
-	}}
-
-	if blogFilter.Search == "" {
-		search = bson.M{"$match": bson.M{}}
+	sort := bson.M{
+		"$sort": bson.M{"score": -1},
 	}
 
+	fuzzy := bson.M{
+		"maxEdits":      2,
+		"prefixLength":  0,
+		"maxExpansions": 50,
+	}
+
+	search := bson.M{
+		"$search": bson.M{
+			"index": "default",
+			"compound": bson.M{
+				"should": bson.A{
+					bson.M{
+						"autocomplete": bson.M{
+							"query": blogFilter.Search,
+							"path":  "content",
+							"fuzzy": fuzzy,
+						},
+					},
+
+					bson.M{
+						"autocomplete": bson.M{
+							"query": blogFilter.Search,
+							"path":  "title",
+							"fuzzy": fuzzy,
+						},
+					},
+
+					bson.M{
+						"autocomplete": bson.M{
+							"query": blogFilter.Search,
+							"path":  "author.first_name",
+							"fuzzy": fuzzy,
+						},
+					},
+
+					bson.M{
+						"autocomplete": bson.M{
+							"query": blogFilter.Search,
+							"path":  "author.last_name",
+							"fuzzy": fuzzy,
+						},
+					},
+				},
+				"minimumShouldMatch": 1,
+			},
+		},
+	}
 	paginated := mongopagination.New(collection).Context(c).Limit(blogFilter.Limit).Page(blogFilter.Pages)
-
-	// Aggregate()
 
 	var paginatedData *mongopagination.PaginatedData
 	var err error
 	if filter != nil {
-		paginatedData, err = paginated.Aggregate(search, filter, project)
+		paginatedData, err = paginated.Aggregate(search, filter, project, sort)
 		// paginatedData, err = paginated.Aggregate(bson.M{"$match": bson.M{"title": "ale", "$in": bson.M{"tag": []string{}}}})
 		if err != nil {
 			log.Println("[REPO] error in GET  Filter", err.Error())
@@ -103,6 +143,7 @@ func getFiltered(c context.Context, collection *mongo.Collection, filter bson.M,
 		for _, raw := range paginatedData.Data {
 			var blog entities.Blog
 			if marshallErr := bson.Unmarshal(raw, &blog); marshallErr == nil {
+				blog.Author = nil
 				blogs = append(blogs, blog)
 			}
 
@@ -162,6 +203,7 @@ func (br *blogRepository) CreateBlog(c context.Context, newBlog *entities.Blog) 
 
 	newBlog.ID = insertedBlog.InsertedID.(primitive.ObjectID)
 	newBlog.AuthorName = newBlog.Author.FirstName + " " + newBlog.Author.LastName
+	newBlog.Author = nil
 
 	return *newBlog, nil
 }

--- a/backend/ASTU-backend-group-2/usecase/blog_usecase.go
+++ b/backend/ASTU-backend-group-2/usecase/blog_usecase.go
@@ -40,7 +40,7 @@ func (b *blogUsecase) BatchCreateBlog(c context.Context, newBlogs *[]forms.BlogF
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 			ID:        primitive.NewObjectID(),
-			Author:    *user,
+			Author:    user,
 		}
 
 		blogs = append(blogs, newBlog)
@@ -162,7 +162,7 @@ func (b *blogUsecase) CreateBlog(c context.Context, newBlog *forms.BlogForm, use
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 		ID:        primitive.NewObjectID(),
-		Author:    *user,
+		Author:    user,
 	}
 
 	Blog, err := b.blogRepository.CreateBlog(ctx, &blog)

--- a/backend/ASTU-backend-group-2/usecase/chat_usecase.go
+++ b/backend/ASTU-backend-group-2/usecase/chat_usecase.go
@@ -1,0 +1,187 @@
+package usecase
+
+//
+// import (
+// 	"context"
+// 	"fmt"
+// 	"time"
+
+// 	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/domain/entities"
+// 	gemini "github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/internal/aiutil"
+// 	"github.com/go-playground/validator/v10"
+// )
+
+// type ChatUsecase struct {
+// 	AIService      gemini.AI
+// 	contextTimeout time.Duration
+// 	Repository     entities.ChatRepository
+// }
+
+// var validate = validator.New()
+
+// func NewUsecase(repository entities.ChatRepository, aiService AI, timeout time.Duration) *ChatUsecase {
+// 	return &ChatUsecase{
+// 		Repository:     repository,
+// 		AIService:      aiService,
+// 		contextTimeout: timeout,
+// 	}
+// }
+
+// func (usecase *ChatUsecase) CreateChat(ctx context.Context, userId string) (Chat, error) {
+// 	err := infrastructure.Validate(validate, form)
+// 	if err != nil {
+// 		return Chat{}, err
+// 	}
+
+// 	firstMessageText := fmt.Sprint(
+// 		"> Hello! Please send me either:",
+// 		">",
+// 		"> * **A blog description:** I'll create a well-crafted blog post based on your outline or ideas.",
+// 		"> * **An existing blog post:** I'll provide detailed feedback, including suggestions for improvement, clarity, and engagement.",
+// 		">",
+// 		"> Feel free to share any specific requirements or preferences you have.",
+// 	)
+
+// 	firstMessage := Message{
+// 		Text:   firstMessageText,
+// 		Role:   "model",
+// 		SentAt: time.Now(),
+// 	}
+
+// 	newChat := Chat{
+// 		Title:     "New Chat",
+// 		UserID:    form.UserID,
+// 		History:   []Message{firstMessage},
+// 		CreatedAt: time.Now(),
+// 		UpdatedAt: time.Now(),
+// 	}
+
+// 	newChat, err = usecase.Repository.CreateChat(ctx, newChat)
+// 	if err != nil {
+// 		return Chat{}, err
+// 	}
+
+// 	return newChat, nil
+// }
+
+// func (usecase *ChatUsecase) DeleteChat(ctx context.Context, form DefaultChatForm) error {
+// 	if err := infrastructure.Validate(validate, form); err != nil {
+// 		return err
+// 	}
+
+// 	chat, err := usecase.Repository.GetChat(ctx, form.ChatID)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	if chat.UserID != form.UserID {
+// 		return ErrChatNotFound
+// 	}
+
+// 	return usecase.Repository.DeleteChat(ctx, form.ChatID)
+// }
+
+// func (usecase *ChatUsecase) GenerateChatTitle(ctx context.Context, form TextForm) (string, error) {
+// 	if err := infrastructure.Validate(validate, form); err != nil {
+// 		return "", err
+// 	}
+
+// 	return usecase.AIService.GenerateChatTitle(ctx, form.Text)
+// }
+
+// func (usecase *ChatUsecase) GetChat(ctx context.Context, form DefaultChatForm) (Chat, error) {
+// 	if err := infrastructure.Validate(validate, form); err != nil {
+// 		return Chat{}, err
+// 	}
+
+// 	chat, err := usecase.Repository.GetChat(ctx, form.ChatID)
+// 	if err != nil {
+// 		return Chat{}, err
+// 	}
+
+// 	if chat.ID != form.UserID {
+// 		return Chat{}, ErrChatNotFound
+// 	}
+
+// 	return chat, nil
+// }
+
+// func (usecase *ChatUsecase) GetChats(ctx context.Context, form UserIDForm, pagination infrastructure.PaginationRequest) (infrastructure.PaginationResponse[Chat], error) {
+// 	if err := infrastructure.Validate(validate, form); err != nil {
+// 		return infrastructure.PaginationResponse[Chat]{}, err
+// 	}
+
+// 	if pagination.Limit == 0 {
+// 		pagination.Limit = 10
+// 	}
+// 	if pagination.Page == 0 {
+// 		pagination.Page = 1
+// 	}
+
+// 	return usecase.Repository.GetChats(ctx, form.UserID, pagination)
+// }
+
+// func (usecase *ChatUsecase) SendMessage(ctx context.Context, chatForm DefaultChatForm, textForm TextForm) (Message, error) {
+// 	if err := infrastructure.Validate(validate, chatForm); err != nil {
+// 		return Message{}, err
+// 	}
+
+// 	if err := infrastructure.Validate(validate, textForm); err != nil {
+// 		return Message{}, err
+// 	}
+
+// 	chat, err := usecase.Repository.GetChat(ctx, chatForm.ChatID)
+// 	if err != nil {
+// 		return Message{}, err
+// 	}
+
+// 	if chat.UserID != chatForm.UserID {
+// 		return Message{}, ErrChatNotFound
+// 	}
+
+// 	message := Message{
+// 		Text:   textForm.Text,
+// 		Role:   "user",
+// 		SentAt: time.Now(),
+// 	}
+
+// 	if chat.History == nil {
+// 		title, err := usecase.AIService.GenerateChatTitle(ctx, textForm.Text)
+// 		if err != nil {
+// 			return Message{}, err
+// 		}
+// 		chat.Title = title
+
+// 		_, err = usecase.Repository.UpdateChat(ctx, chatForm.ChatID, chat)
+// 		if err != nil {
+// 			return Message{}, err
+// 		}
+// 	}
+
+// 	response, err := usecase.AIService.SendMessage(ctx, chat.History, message)
+// 	if err != nil {
+// 		return Message{}, err
+// 	}
+
+// 	if err := usecase.Repository.AddMessage(ctx, chatForm.ChatID, message); err != nil {
+// 		return Message{}, err
+// 	}
+
+// 	if err := usecase.Repository.AddMessage(ctx, chatForm.ChatID, response); err != nil {
+// 		return Message{}, err
+// 	}
+
+// 	return response, nil
+// }
+
+// func (usecase *ChatUsecase) UpdateChat(ctx context.Context, form DefaultChatForm, updatedChat Chat) (Chat, error) {
+// 	if err := infrastructure.Validate(validate, form); err != nil {
+// 		return Chat{}, err
+// 	}
+
+// 	if err := infrastructure.Validate(validate, updatedChat); err != nil {
+// 		return Chat{}, err
+// 	}
+
+// 	return usecase.Repository.UpdateChat(ctx, form.ChatID, updatedChat)
+// }


### PR DESCRIPTION
Refactor the `Author` field in the `Blog` struct of the `entities` package and the `blogUsecase` to use a pointer to the `User` struct instead of the `User` struct itself. This change ensures consistency and improves memory efficiency by avoiding unnecessary copying of the `User` struct.