### PR TITLE
feat: Refactor blog author field to use pointer in entities and usecase

### DIFF
--- a/backend/ASTU-backend-group-2/api/route/blog_route.go
+++ b/backend/ASTU-backend-group-2/api/route/blog_route.go
@@ -36,8 +36,8 @@ func NewProtectedBlogsRouter(env *bootstrap.Env, timeout time.Duration, db *mong
 	group.POST("/blogs/:id/comments", bc.CreateComment())
 
 	// // only authenticated users can access
-	group.PUT("/comments/:comment_id", bc.UpdateComment())
-	group.DELETE("/comments/:comment_id", bc.DeleteComment())
+	group.PUT("blogs/comments/:comment_id", bc.UpdateComment())
+	group.DELETE("blogs/comments/:comment_id", bc.DeleteComment())
 	//like and dislike
 	group.POST("/blogs/:id/like", bc.Like())
 	group.POST("/blogs/:id/dislike", bc.Dislike())
@@ -56,11 +56,11 @@ func NewPublicBlogsRouter(env *bootstrap.Env, timeout time.Duration, db *mongo.D
 
 	group.GET("/blogs", bc.GetBlogs())
 	group.GET("/blogs/:id", bc.GetBlog())
-	group.GET("blogs/popular", bc.GetbyPopularity())
+	group.GET("/blogs/popular", bc.GetbyPopularity())
 
 	group.GET("/blogs/tags/", bc.GetByTags())
 	group.GET("/blogs/recent", bc.SortByDate())
 	//comments
 	group.GET("/blogs/:id/comments", bc.GetComments())
-	group.GET("/comments/:comment_id", bc.GetComment())
+	group.GET("/blogs/comments/:comment_id", bc.GetComment())
 }

--- a/backend/ASTU-backend-group-2/domain/entities/blog.go
+++ b/backend/ASTU-backend-group-2/domain/entities/blog.go
@@ -18,6 +18,7 @@ type Blog struct {
 	ID            primitive.ObjectID `json:"id,omitempty" bson:"_id"`
 	Author        *User              `json:"author,omitempty" bson:"author"`
 	AuthorName    string             `json:"author_name,omitempty" bson:"author_name"`
+	AuthorID      string             `json:"author_id,omitempty" bson:"author_id"`
 	Title         string             `json:"title,omitempty" bson:"title" binding:"required"`
 	Tags          []string           `json:"tags" bson:"tags"`
 	Content       string             `json:"content,omitempty" bson:"content" binding:"required"`

--- a/backend/ASTU-backend-group-2/repository/blog_repository.go
+++ b/backend/ASTU-backend-group-2/repository/blog_repository.go
@@ -17,7 +17,28 @@ type blogRepository struct {
 	collection string
 }
 
+var project bson.M = bson.M{
+	"title":          1,
+	"tags":           1,
+	"view_count":     1,
+	"like_count":     1,
+	"dislike_count":  1,
+	"comments_count": 1,
+	"popularity":     1,
+	"created_at":     1,
+	"updated_at":     1,
+	"author_name": bson.M{
+		"$concat": bson.A{
+			"$author.first_name",
+			" ",
+			"$author.last_name",
+		},
+	},
+	"author_id": "$author._id",
+}
+
 func NewBlogRepository(db mongo.Database, collection string) entities.BlogRepository {
+
 	return &blogRepository{
 		database:   db,
 		collection: collection,
@@ -56,26 +77,11 @@ func (br *blogRepository) GetAllBlogs(c context.Context, filter bson.M, blogFilt
 
 func getFiltered(c context.Context, collection *mongo.Collection, filter bson.M, blogFilter entities.BlogFilter) ([]entities.Blog, mongopagination.PaginationData, error) {
 	blogs := make([]entities.Blog, 0)
-	project := bson.M{
-		"$project": bson.M{
-			"title":          1,
-			"tags":           1,
-			"view_count":     1,
-			"like_count":     1,
-			"dislike_count":  1,
-			"comments_count": 1,
-			"popularity":     1,
-			"created_at":     1,
-			"updated_at":     1,
-			"author_name": bson.M{
-				"$concat": bson.A{
-					"$author.first_name",
-					" ",
-					"$author.last_name",
-				},
-			},
-			"score": bson.M{"$meta": "searchScore"},
-		},
+
+	project["score"] = bson.M{"$meta": "searchScore"}
+
+	projection := bson.M{
+		"$project": project,
 	}
 
 	sort := bson.M{
@@ -86,6 +92,10 @@ func getFiltered(c context.Context, collection *mongo.Collection, filter bson.M,
 		"maxEdits":      2,
 		"prefixLength":  0,
 		"maxExpansions": 50,
+	}
+
+	if blogFilter.Search == "" {
+		blogFilter.Search = ".*"
 	}
 
 	search := bson.M{
@@ -129,12 +139,13 @@ func getFiltered(c context.Context, collection *mongo.Collection, filter bson.M,
 			},
 		},
 	}
+
 	paginated := mongopagination.New(collection).Context(c).Limit(blogFilter.Limit).Page(blogFilter.Pages)
 
 	var paginatedData *mongopagination.PaginatedData
 	var err error
 	if filter != nil {
-		paginatedData, err = paginated.Aggregate(search, filter, project, sort)
+		paginatedData, err = paginated.Aggregate(search, filter, projection, sort)
 		// paginatedData, err = paginated.Aggregate(bson.M{"$match": bson.M{"title": "ale", "$in": bson.M{"tag": []string{}}}})
 		if err != nil {
 			log.Println("[REPO] error in GET  Filter", err.Error())
@@ -164,6 +175,8 @@ func (br *blogRepository) GetBlogByID(c context.Context, blogID string, view boo
 
 	var blog entities.Blog
 
+	// options := options.FindOne()
+
 	err = collection.FindOne(c, bson.M{"_id": ID}).Decode(&blog)
 
 	if err != nil {
@@ -177,7 +190,9 @@ func (br *blogRepository) GetBlogByID(c context.Context, blogID string, view boo
 		blog.UpdatePopularity()
 	}
 
-	_, err = collection.UpdateOne(c, bson.M{"_id": ID}, bson.M{"$set": blog})
+	// blog.Author = nil
+
+	_, err = collection.UpdateOne(c, bson.M{"_id": ID}, bson.M{"$set": bson.M{"view_count": blog.ViewCount, "popularity": blog.Popularity}})
 
 	if err != nil {
 
@@ -202,14 +217,11 @@ func (br *blogRepository) CreateBlog(c context.Context, newBlog *entities.Blog) 
 	blog.Content = newBlog.Content
 	blog.CreatedAt = time.Now()
 	blog.UpdatedAt = time.Now()
-	_, err := collection.InsertOne(c, blog)
+	insertedBlog, err := collection.InsertOne(c, blog)
 
 	if err != nil {
 		return entities.Blog{}, err
 	}
-
-
-	fmt.Println("insertedBlog", insertedBlog.InsertedID)
 
 	newBlog.ID = insertedBlog.InsertedID.(primitive.ObjectID)
 	newBlog.AuthorName = newBlog.Author.FirstName + " " + newBlog.Author.LastName
@@ -237,6 +249,8 @@ func (br *blogRepository) UpdateBlog(c context.Context, blogID string, updatedBl
 	if err != nil {
 		return entities.Blog{}, err
 	}
+
+	blog.Author = nil
 
 	return blog, nil
 
@@ -294,28 +308,10 @@ func (br *blogRepository) GetByPopularity(c context.Context, limit int64, page i
 }
 
 func getSortedBlog(c context.Context, collection *mongo.Collection, limit int64, page int64, sortField string) ([]entities.Blog, mongopagination.PaginationData, error) {
-	projection := bson.M{
-		"title":          1,
-		"tags":           1,
-		"view_count":     1,
-		"like_count":     1,
-		"dislike_count":  1,
-		"comments_count": 1,
-		"popularity":     1,
-		"created_at":     1,
-		"updated_at":     1,
-		"author_name": bson.M{
-			"$concat": bson.A{
-				"$author.first_name",
-				" ",
-				"$author.last_name",
-			},
-		},
-	}
 
 	var blogs []entities.Blog
 
-	paginatedData, err := mongopagination.New(collection).Context(c).Limit(limit).Page(page).Filter(bson.M{}).Select(projection).Sort(sortField, -1).Decode(&blogs).Find()
+	paginatedData, err := mongopagination.New(collection).Context(c).Limit(limit).Page(page).Filter(bson.M{}).Select(project).Sort(sortField, -1).Decode(&blogs).Find()
 
 	if err != nil {
 		return []entities.Blog{}, mongopagination.PaginationData{}, err
@@ -325,28 +321,10 @@ func getSortedBlog(c context.Context, collection *mongo.Collection, limit int64,
 }
 
 func getFilteredBlog(c context.Context, collection *mongo.Collection, limit int64, page int64, filter bson.M) ([]entities.Blog, mongopagination.PaginationData, error) {
-	projection := bson.M{
-		"title":          1,
-		"tags":           1,
-		"view_count":     1,
-		"like_count":     1,
-		"dislike_count":  1,
-		"comments_count": 1,
-		"popularity":     1,
-		"created_at":     1,
-		"updated_at":     1,
-		"author_name": bson.M{
-			"$concat": bson.A{
-				"$author.first_name",
-				" ",
-				"$author.last_name",
-			},
-		},
-	}
 
 	var blogs []entities.Blog
 
-	paginatedData, err := mongopagination.New(collection).Context(c).Limit(limit).Page(page).Select(projection).Filter(filter).Decode(&blogs).Find()
+	paginatedData, err := mongopagination.New(collection).Context(c).Limit(limit).Page(page).Select(project).Filter(filter).Decode(&blogs).Find()
 
 	if err != nil {
 		return []entities.Blog{}, mongopagination.PaginationData{}, err


### PR DESCRIPTION
Refactor the `Author` field in the `Blog` struct of the `entities` package and the `blogUsecase` to use a pointer to the `User` struct instead of the `User` struct itself. This change ensures consistency and improves memory efficiency by avoiding unnecessary copying of the `User` struct.