### PR TITLE
chore: Refactor error handling in chat and reset password controllers

### DIFF
--- a/backend/ASTU-backend-group-2/.env.example
+++ b/backend/ASTU-backend-group-2/.env.example
@@ -45,3 +45,8 @@ PASS_RESET_CODE_EXPIRATION_MIN=5
 CLOUDINARY_NAME=your_cloudinary_name
 CLOUDINARY_KEY=your_cloudinary_api_key
 CLOUDINARY_SECRET=your_cloudinary_secret
+
+
+# Rate Limiting Configuration
+RATE_LIMIT_MAX_REQUEST=max_req
+RATE_LIMIT_EXPIRATION_MIN=minutesTreshold

--- a/backend/ASTU-backend-group-2/api/controller/chat_controller.go
+++ b/backend/ASTU-backend-group-2/api/controller/chat_controller.go
@@ -2,45 +2,178 @@ package controller
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"strconv"
 
+	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/api/middleware"
 	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/bootstrap"
-	gemini "github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/internal/aiutil"
+	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/domain/entities"
+	custom_error "github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/domain/errors"
+	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/domain/forms"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-type ChatController struct {
-	Env *bootstrap.Env
+type chatController interface {
+	Chat(ctx context.Context) gin.HandlerFunc
+	ChatHandler(ctx context.Context) gin.HandlerFunc
 }
 
-func (sc *ChatController) Chat(ctx context.Context) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		type ChatRequest struct {
-			Title       string `json:"title"`
-			Description string `json:"description"`
-		}
+type ChatController struct {
+	ChatUsecase entities.ChatUsecase
+	Env         *bootstrap.Env
+}
 
-		var chatRequest ChatRequest
+func (cc *ChatController) CreateChat(c *gin.Context) {
 
-		if err := c.ShouldBindJSON(&chatRequest); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
+	userID := c.Value("x-user-id").(string)
 
-		chat_gemini := gemini.NewAIUtil(sc.Env)
+	ID, err := primitive.ObjectIDFromHex(userID)
 
-		res, err := chat_gemini.GenerateContentFromGemini(
-			chatRequest.Title,
-			chatRequest.Description,
-			*sc.Env,
-		)
-
-		if err != nil {
-			c.Error(err)
-			return
-		}
-
-		c.JSON(http.StatusOK, gin.H{"response": res})
-
+	if err != nil {
+		c.JSON(http.StatusBadRequest, custom_error.ErrMessage(custom_error.ErrInvalidID))
+		return
 	}
+
+	newChat, err := cc.ChatUsecase.CreateChat(c.Request.Context(), ID)
+
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, newChat)
+
+}
+
+func (cc *ChatController) GetChat(c *gin.Context) {
+	chatId := c.Param("id")
+	userId := c.Value("x-user-id").(string)
+
+	ChatID, err := primitive.ObjectIDFromHex(chatId)
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, custom_error.ErrMessage(custom_error.ErrInvalidID))
+		return
+	}
+
+	UserID, err := primitive.ObjectIDFromHex(userId)
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, custom_error.ErrMessage(custom_error.ErrInvalidID))
+		return
+	}
+
+	chats, err := cc.ChatUsecase.GetChat(c.Request.Context(), UserID, ChatID)
+
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, chats)
+}
+
+func (cc *ChatController) GetChats(c *gin.Context) {
+	userId := c.Value("x-user-id").(string)
+
+	UserID, err := primitive.ObjectIDFromHex(userId)
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, custom_error.ErrMessage(custom_error.ErrInvalidID))
+		return
+	}
+
+	page, _ := strconv.ParseInt(c.Query("page"), 10, 64)
+	limit, _ := strconv.ParseInt(c.Query("limit"), 10, 64)
+
+	chatsRes := make([]entities.Chat, 0)
+
+	chats, pagination, err := cc.ChatUsecase.GetChats(c.Request.Context(), UserID, limit, page)
+
+	if chats != nil {
+		for _, chat := range *chats {
+			chatsRes = append(chatsRes, chat)
+		}
+	}
+
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	res := entities.PaginatedResponse{
+		Data:     chatsRes,
+		MetaData: pagination,
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (cc *ChatController) SendMessage(c *gin.Context) {
+	var messageForm forms.MessageForm
+	if err := c.ShouldBindJSON(&messageForm); err != nil {
+		if err == io.EOF {
+			c.JSON(http.StatusBadRequest, custom_error.ErrMessage(custom_error.EreInvalidRequestBody))
+			return
+		}
+		middleware.CustomErrorResponse(c, err)
+		return
+	}
+
+	chatId := c.Param("id")
+	userId := c.Value("x-user-id").(string)
+
+	ChatID, err := primitive.ObjectIDFromHex(chatId)
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, custom_error.ErrMessage(custom_error.ErrInvalidID))
+		return
+	}
+
+	UserID, err := primitive.ObjectIDFromHex(userId)
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, custom_error.ErrMessage(custom_error.ErrInvalidID))
+		return
+	}
+
+	response, err := cc.ChatUsecase.CreateMessage(c.Request.Context(), UserID, ChatID, messageForm.Message)
+
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+
+}
+
+func (cc *ChatController) DeleteChat(c *gin.Context) {
+	chatId := c.Param("id")
+	userId := c.Value("x-user-id").(string)
+
+	ChatID, err := primitive.ObjectIDFromHex(chatId)
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, custom_error.ErrMessage(custom_error.ErrInvalidID))
+		return
+	}
+
+	UserID, err := primitive.ObjectIDFromHex(userId)
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, custom_error.ErrMessage(custom_error.ErrInvalidID))
+		return
+	}
+
+	err = cc.ChatUsecase.DeleteChat(c.Request.Context(), UserID, ChatID)
+
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "chat deleted successfully"})
 }

--- a/backend/ASTU-backend-group-2/api/middleware/rate_limit_handler_middleware.go
+++ b/backend/ASTU-backend-group-2/api/middleware/rate_limit_handler_middleware.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/bootstrap"
+	custom_error "github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/domain/errors"
+	"github.com/gin-gonic/gin"
+)
+
+type RateLimitMiddleware struct {
+	MaxRequest     int
+	Expiration     time.Duration
+	RequestStorage map[string]*Request
+}
+
+type Request struct {
+	Count int
+	Last  time.Time
+}
+
+func NewRateLimitterMiddleware(env *bootstrap.Env) *RateLimitMiddleware {
+	maxRequest := env.RateLimitMaxRequest
+	expiration := env.RateLimitExpirationMin
+
+	return &RateLimitMiddleware{
+		MaxRequest:     maxRequest,
+		Expiration:     time.Minute * time.Duration(expiration),
+		RequestStorage: make(map[string]*Request),
+	}
+}
+
+func (r *RateLimitMiddleware) RateLimitter(c *gin.Context) {
+	ip := c.ClientIP()
+	request, ok := r.RequestStorage[ip]
+	if !ok {
+		request = &Request{
+			Count: 0,
+			Last:  time.Now(),
+		}
+		r.RequestStorage[ip] = request
+	}
+
+	if request.Count >= r.MaxRequest {
+		if time.Since(request.Last) < r.Expiration {
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, custom_error.ErrMessage(custom_error.ErrRateLimitExceeded))
+			return
+		}
+		request.Count = 0
+	}
+
+	request.Count++
+	request.Last = time.Now()
+	c.Next()
+
+}

--- a/backend/ASTU-backend-group-2/api/route/chat_route.go
+++ b/backend/ASTU-backend-group-2/api/route/chat_route.go
@@ -1,19 +1,29 @@
 package route
 
 import (
-	"context"
 	"time"
 
 	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/api/controller"
 	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/bootstrap"
+	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/domain/entities"
+	gemini "github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/internal/aiutil"
+	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/repository"
+	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/usecase"
 	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func NewChatRouter(env *bootstrap.Env, timeout time.Duration, group *gin.RouterGroup) {
+func NewChatRouter(env *bootstrap.Env, timeout time.Duration, db *mongo.Database, group *gin.RouterGroup) {
+	cr := repository.NewChatRepository(*db, entities.CollectionChat)
+	aiService := gemini.NewAIUtil(env)
 	cc := controller.ChatController{
-		Env: env,
+		ChatUsecase: usecase.NewChatUsecase(cr, *aiService, timeout),
+		Env:         env,
 	}
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
-	defer cancel()
-	group.POST("/chat", cc.Chat(ctx))
+
+	group.GET("chats/", cc.GetChats)
+	group.POST("chat/", cc.CreateChat)
+	group.GET("chat/:id", cc.GetChat)
+	group.DELETE("chat/:id", cc.DeleteChat)
+	group.POST("chat/:id/interact", cc.SendMessage)
 }

--- a/backend/ASTU-backend-group-2/api/route/route.go
+++ b/backend/ASTU-backend-group-2/api/route/route.go
@@ -15,6 +15,10 @@ func Setup(env *bootstrap.Env, timeout time.Duration, db *mongo.Database, gin *g
 	// Error handling
 	gin.Use(middleware.ErrorHandlerMiddleware())
 
+	// RateLimit handling
+	rateLimit := middleware.NewRateLimitterMiddleware(env)
+	gin.Use(rateLimit.RateLimitter)
+
 	publicRouter := gin.Group("")
 
 	// All Public APIs
@@ -34,5 +38,5 @@ func Setup(env *bootstrap.Env, timeout time.Duration, db *mongo.Database, gin *g
 	// All Protected APIs
 	NewProtectedBlogsRouter(env, timeout, db, protectedRouter)
 	NewProfileRouter(env, timeout, db, protectedRouter, cloudinary)
-	NewChatRouter(env, timeout, protectedRouter)
+	NewChatRouter(env, timeout, db, protectedRouter)
 }

--- a/backend/ASTU-backend-group-2/bootstrap/env.go
+++ b/backend/ASTU-backend-group-2/bootstrap/env.go
@@ -35,6 +35,8 @@ type Env struct {
 	CloudinaryName             string `mapstructure:"CLOUDINARY_NAME"`
 	CloudinaryKey              string `mapstructure:"CLOUDINARY_KEY"`
 	CloudinarySecret           string `mapstructure:"CLOUDINARY_SECRET"`
+	RateLimitMaxRequest        int    `mapstructure:"RATE_LIMIT_MAX_REQUEST"`
+	RateLimitExpirationMin     int    `mapstructure:"RATE_LIMIT_EXPIRATION_MIN"`
 }
 
 func NewEnv() *Env {

--- a/backend/ASTU-backend-group-2/domain/entities/chat.go
+++ b/backend/ASTU-backend-group-2/domain/entities/chat.go
@@ -8,6 +8,10 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+const (
+	CollectionChat = "chat"
+)
+
 type Chat struct {
 	ID        primitive.ObjectID `json:"id,omitempty" bson:"_id,omitempty" `
 	UserID    primitive.ObjectID `json:"user_id,omitempty" bson:"user_id,omitempty"`
@@ -24,19 +28,20 @@ type Message struct {
 }
 
 type ChatUsecase interface {
-	CreateChat(c context.Context, userId string) (Chat, error)
-	GetChat(c context.Context, chatId string) (Chat, error)
-	GetChats(c context.Context, userId string, limit int64, page int64) ([]Chat, mongopagination.PaginationData, error)
-	CreateMessage(c context.Context, userId string, chatId string, body string) (Message, error)
-	DeleteChat(c context.Context, chatId string) error
+	CreateChat(c context.Context, userId primitive.ObjectID) (Chat, error)
+	GetChat(c context.Context, userId primitive.ObjectID, chatId primitive.ObjectID) (Chat, error)
+	GetChats(c context.Context, userId primitive.ObjectID, limit int64, page int64) (*[]Chat, mongopagination.PaginationData, error)
+	CreateMessage(c context.Context, userId primitive.ObjectID, chatId primitive.ObjectID, body string) (Message, error)
+	DeleteChat(c context.Context, userId primitive.ObjectID, chatId primitive.ObjectID) error
 }
 
 type ChatRepository interface {
 	CreateChat(c context.Context, chat Chat) (Chat, error)
-	GetChat(c context.Context, chatID string) (Chat, error)
-	GetChats(c context.Context, userID string, limit int64, page int64) ([]Chat, mongopagination.PaginationData, error)
-	CreateMessage(c context.Context, chatID string, body Message) error
-	DeleteChat(c context.Context, chatID string) error
+	GetChat(c context.Context, chatID primitive.ObjectID) (Chat, error)
+	GetChats(c context.Context, userID primitive.ObjectID, limit int64, page int64) (*[]Chat, mongopagination.PaginationData, error)
+	CreateMessage(c context.Context, chatID primitive.ObjectID, body Message) error
+	DeleteChat(c context.Context, chatID primitive.ObjectID) error
+	UpdateChat(ctx context.Context, chatID primitive.ObjectID, updatedChat Chat) (Chat, error)
 }
 
 type AI interface {

--- a/backend/ASTU-backend-group-2/domain/entities/user.go
+++ b/backend/ASTU-backend-group-2/domain/entities/user.go
@@ -139,4 +139,6 @@ type UserRepository interface {
 
 	PromoteUserToAdmin(c context.Context, userID string) error
 	DemoteAdminToUser(c context.Context, userID string) error
+	GetInactiveUsersForReactivation(c context.Context, emailTreshold primitive.DateTime, deleteTreshold primitive.DateTime) (*[]User, error)
+	DeleteInActiveUser(c context.Context, deleteTreshold primitive.DateTime) error
 }

--- a/backend/ASTU-backend-group-2/domain/errors/error_response.go
+++ b/backend/ASTU-backend-group-2/domain/errors/error_response.go
@@ -50,6 +50,9 @@ var (
 	ErrErrorSendingVerificationEmail = errors.New("Error sending verification email")
 	ErrInvalidEmailFormat            = errors.New("Invalid email format")
 	EreInvalidRequestBody            = errors.New("Request body cannot be empty")
+
+	ErrRateLimitExceeded         = errors.New("Rate limit exceeded")
+	ErrErrorSendingReminderEmail = errors.New("Error sending reminder email")
 )
 
 // Token Errors
@@ -116,8 +119,15 @@ var (
 	ErrErrorCountingBlogViews    = errors.New("Error counting blog views")
 	ErrErrorCountingUserPosts    = errors.New("Error counting user blogs")
 	ErrFilteringBlogs            = errors.New("Error filtering blogs")
+	ErrFilteringChats            = errors.New("Error filtering chats")
+	ErrCreatingChat              = errors.New("Error creating chat")
 	ErrFilteringComments         = errors.New("Error filtering comments")
 	ErrUpdatingLikeCount         = errors.New("Error updating like count")
+)
+
+// Chat Errors
+var (
+	ErrChatNotFound = errors.New("Chat not found")
 )
 
 var errorStatusMap = map[error]int{

--- a/backend/ASTU-backend-group-2/domain/forms/chat_form.go
+++ b/backend/ASTU-backend-group-2/domain/forms/chat_form.go
@@ -1,0 +1,10 @@
+package forms
+
+type CreateChatForm struct {
+	UserID string `json:"user_id,omitempty" binding:"required,hexadecimal"`
+	Title  string `json:"title,omitempty" binding:"required,min=5,max=30"`
+}
+
+type MessageForm struct {
+	Message string `json:"message,omitempty" binding:"required,min=5,max=300"`
+}

--- a/backend/ASTU-backend-group-2/internal/aiutil/chat_gemini.go
+++ b/backend/ASTU-backend-group-2/internal/aiutil/chat_gemini.go
@@ -16,15 +16,11 @@ import (
 	"google.golang.org/api/option"
 )
 
-type AIUtil interface {
-	GenerateContentFromGemini(title string, description string, env bootstrap.Env) (string, error)
-}
-
 type AI struct {
 	model *genai.GenerativeModel
 }
 
-func NewAIUtil(env *bootstrap.Env) AIUtil {
+func NewAIUtil(env *bootstrap.Env) *AI {
 	ctx := context.Background()
 
 	client, err := genai.NewClient(ctx, option.WithAPIKey(env.GeminiAPIKey))
@@ -147,26 +143,62 @@ func (ai *AI) ReviewContent(blogContent string) (string, error) {
 	return suggestions, nil
 }
 
+// func (aiService *AI) SendMessage(ctx context.Context, history []entities.Message, message entities.Message) (entities.Message, error) {
+// 	var chatSessionHistory []*genai.Content
+// 	for _, message := range history {
+// 		content := genai.Content{
+// 			Parts: []genai.Part{
+// 				genai.Text(message.Text),
+// 			},
+
+// 			Role: message.Role,
+// 		}
+
+// 		chatSessionHistory = append(chatSessionHistory, &content)
+// 	}
+
+// 	chatSession := aiService.model.StartChat()
+// 	chatSession.History = chatSessionHistory
+
+// 	response, err := chatSession.SendMessage(ctx, genai.Text(message.Text))
+// 	if err != nil {
+// 		return entities.Message{}, err
+// 	}
+
+// 	candidate := response.Candidates[0]
+// 	return entities.Message{
+// 		Text:      fmt.Sprintf("%s", candidate.Content.Parts[0]),
+// 		Role:      candidate.Content.Role,
+// 		CreatedAt: time.Now(),
+// 	}, nil
+// }
+
 func (aiService *AI) SendMessage(ctx context.Context, history []entities.Message, message entities.Message) (entities.Message, error) {
 	var chatSessionHistory []*genai.Content
-	for _, message := range history {
+	for _, msg := range history {
 		content := genai.Content{
 			Parts: []genai.Part{
-				genai.Text(message.Text),
+				genai.Text(msg.Text),
 			},
-
-			Role: message.Role,
+			Role: msg.Role,
 		}
 
 		chatSessionHistory = append(chatSessionHistory, &content)
 	}
 
 	chatSession := aiService.model.StartChat()
+	if chatSession == nil {
+		return entities.Message{}, fmt.Errorf("failed to start chat session")
+	}
 	chatSession.History = chatSessionHistory
 
 	response, err := chatSession.SendMessage(ctx, genai.Text(message.Text))
 	if err != nil {
 		return entities.Message{}, err
+	}
+
+	if len(response.Candidates) == 0 {
+		return entities.Message{}, fmt.Errorf("no candidates found in response")
 	}
 
 	candidate := response.Candidates[0]

--- a/backend/ASTU-backend-group-2/repository/action_repository.go
+++ b/backend/ASTU-backend-group-2/repository/action_repository.go
@@ -13,13 +13,13 @@ import (
 
 type reactionRepository struct {
 	db         *mongo.Database
-	Collection *mongo.Collection
+	collection *mongo.Collection
 }
 
 func NewReactionRepository(database *mongo.Database) entities.ReactionRepository {
 	return reactionRepository{
 		db:         database,
-		Collection: database.Collection("blogs"),
+		collection: database.Collection(entities.CollectionBlog),
 	}
 }
 
@@ -42,7 +42,7 @@ func (ar reactionRepository) Like(c context.Context, blogID, userID string) erro
 	//blogs collection likes field
 
 	log.Printf("filter: %v", filter)
-	res, err := ar.Collection.UpdateOne(c, filter, bson.M{"$addToSet": bson.M{"likes": userObjID}})
+	res, err := ar.collection.UpdateOne(c, filter, bson.M{"$addToSet": bson.M{"likes": userObjID}})
 	if err != nil {
 		log.Printf("error while updating the document. Error: %v", err)
 		return err
@@ -67,7 +67,7 @@ func (ar reactionRepository) Dislike(c context.Context, blogID, userID string) e
 
 	filter := bson.M{"_id": blogObjID}
 
-	res, err := ar.Collection.UpdateOne(c, filter, bson.M{"$addToSet": bson.M{"dislikes": userObjID}})
+	res, err := ar.collection.UpdateOne(c, filter, bson.M{"$addToSet": bson.M{"dislikes": userObjID}})
 	if res.ModifiedCount < 1 {
 		return custom_error.ErrBlogNotFound
 	}
@@ -85,7 +85,7 @@ func (ar reactionRepository) RemoveLike(c context.Context, blogID, userID string
 		return custom_error.ErrInvalidID
 	}
 	filter := bson.M{"_id": blogObjID}
-	res, err := ar.Collection.UpdateOne(c, filter, bson.M{"$pull": bson.M{"likes": userObjID}})
+	res, err := ar.collection.UpdateOne(c, filter, bson.M{"$pull": bson.M{"likes": userObjID}})
 	if res.ModifiedCount < 1 {
 		return custom_error.ErrBlogNotFound
 	}
@@ -102,7 +102,7 @@ func (ar reactionRepository) RemoveDislike(c context.Context, blogID, userID str
 		return custom_error.ErrInvalidID
 	}
 	filter := bson.M{"_id": blogObjID}
-	res, err := ar.Collection.UpdateOne(c, filter, bson.M{"$pull": bson.M{"dislikes": userObjID}})
+	res, err := ar.collection.UpdateOne(c, filter, bson.M{"$pull": bson.M{"dislikes": userObjID}})
 	if res.ModifiedCount < 1 {
 		return custom_error.ErrBlogNotFound
 	}
@@ -123,7 +123,7 @@ func (ar reactionRepository) IsPostLiked(c context.Context, blogID, userID strin
 		"likes": bson.M{"$in": []primitive.ObjectID{userObjID}},
 	}
 
-	count, err := ar.Collection.CountDocuments(c, filter)
+	count, err := ar.collection.CountDocuments(c, filter)
 	if err != nil {
 		return false, custom_error.ErrErrorCountingBlogLikes
 	}
@@ -142,7 +142,7 @@ func (ar reactionRepository) IsPostDisliked(c context.Context, blogID, userID st
 		"_id":      blogObjID,
 		"dislikes": bson.M{"$in": []primitive.ObjectID{userObjID}},
 	}
-	count, err := ar.Collection.CountDocuments(c, filter)
+	count, err := ar.collection.CountDocuments(c, filter)
 	if err != nil {
 		return false, custom_error.ErrErrorCountingBlogDisLikes
 	}

--- a/backend/ASTU-backend-group-2/repository/blog_repository.go
+++ b/backend/ASTU-backend-group-2/repository/blog_repository.go
@@ -15,8 +15,8 @@ import (
 )
 
 type blogRepository struct {
-	database   mongo.Database
-	collection string
+	database       mongo.Database
+	collectionName string
 }
 
 var project bson.M = bson.M{
@@ -42,14 +42,14 @@ var project bson.M = bson.M{
 func NewBlogRepository(db mongo.Database, collection string) entities.BlogRepository {
 
 	return &blogRepository{
-		database:   db,
-		collection: collection,
+		database:       db,
+		collectionName: collection,
 	}
 }
 
 // BatchCreateBlog implements entities.BlogRepository.
 func (br *blogRepository) BatchCreateBlog(c context.Context, newBlogs *[]entities.Blog) error {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	var blogs []interface{}
 
@@ -68,7 +68,7 @@ func (br *blogRepository) BatchCreateBlog(c context.Context, newBlogs *[]entitie
 }
 
 func (br *blogRepository) GetByTags(c context.Context, tags []string, limit int64, page int64) ([]entities.Blog, mongopagination.PaginationData, error) {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	filter := bson.M{"tags": bson.M{"$in": tags}}
 
@@ -76,7 +76,7 @@ func (br *blogRepository) GetByTags(c context.Context, tags []string, limit int6
 }
 
 func (br *blogRepository) GetAllBlogs(c context.Context, filter bson.M, blogFilter entities.BlogFilter) ([]entities.Blog, mongopagination.PaginationData, error) {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	return getFiltered(c, collection, filter, blogFilter)
 }
@@ -173,7 +173,7 @@ func getFiltered(c context.Context, collection *mongo.Collection, filter bson.M,
 }
 
 func (br *blogRepository) GetBlogByID(c context.Context, blogID string, view bool) (entities.Blog, error) {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	ID, err := primitive.ObjectIDFromHex(blogID)
 
@@ -212,7 +212,7 @@ func (br *blogRepository) GetBlogByID(c context.Context, blogID string, view boo
 }
 
 func (br *blogRepository) CreateBlog(c context.Context, newBlog *entities.Blog) (entities.Blog, error) {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 	blog := entities.Blog{}
 	blog.ID = primitive.NewObjectID()
 
@@ -235,7 +235,7 @@ func (br *blogRepository) CreateBlog(c context.Context, newBlog *entities.Blog) 
 }
 
 func (br *blogRepository) UpdateBlog(c context.Context, blogID string, updatedBlog *entities.BlogUpdate) (entities.Blog, error) {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	ID, err := primitive.ObjectIDFromHex(blogID)
 
@@ -259,7 +259,7 @@ func (br *blogRepository) UpdateBlog(c context.Context, blogID string, updatedBl
 }
 
 func (br *blogRepository) DeleteBlog(c context.Context, blogID string) error {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	ID, err := primitive.ObjectIDFromHex(blogID)
 
@@ -278,14 +278,14 @@ func (br *blogRepository) DeleteBlog(c context.Context, blogID string) error {
 }
 
 func (br *blogRepository) SortByDate(c context.Context, limit int64, page int64) ([]entities.Blog, mongopagination.PaginationData, error) {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	return getSortedBlog(c, collection, limit, page, "created_at")
 
 }
 
 func (br *blogRepository) SortByComment(c context.Context, limit int64, page int64) ([]entities.Blog, mongopagination.PaginationData, error) {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	return getSortedBlog(c, collection, limit, page, "comments_count")
 
@@ -293,14 +293,14 @@ func (br *blogRepository) SortByComment(c context.Context, limit int64, page int
 
 func (br *blogRepository) SortByLikes(c context.Context, limit int64, page int64) ([]entities.Blog, mongopagination.PaginationData, error) {
 
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	return getSortedBlog(c, collection, limit, page, "comments_likes")
 
 }
 
 func (br *blogRepository) GetByPopularity(c context.Context, limit int64, page int64) ([]entities.Blog, mongopagination.PaginationData, error) {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	return getSortedBlog(c, collection, limit, page, "popularity")
 }
@@ -331,7 +331,7 @@ func getFilteredBlog(c context.Context, collection *mongo.Collection, limit int6
 	return blogs, paginatedData.Pagination, nil
 }
 func (br *blogRepository) UpdateLikeCount(c context.Context, blogID string, increment bool) error {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	// Convert blogID to a MongoDB ObjectID
 	ID, err := primitive.ObjectIDFromHex(blogID)
@@ -364,7 +364,7 @@ func (br *blogRepository) UpdateLikeCount(c context.Context, blogID string, incr
 }
 
 func (br *blogRepository) UpdateDislikeCount(c context.Context, blogID string, increment bool) error {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 
 	// Convert blogID to a MongoDB ObjectID
 	ID, err := primitive.ObjectIDFromHex(blogID)
@@ -396,7 +396,7 @@ func (br *blogRepository) UpdateDislikeCount(c context.Context, blogID string, i
 	return nil
 }
 func (br *blogRepository) UpdateCommentCount(c context.Context, blogID string, increment bool) error {
-	collection := br.database.Collection(br.collection)
+	collection := br.database.Collection(br.collectionName)
 	ID, err := primitive.ObjectIDFromHex(blogID)
 
 	if err != nil {

--- a/backend/ASTU-backend-group-2/repository/chat_repository.go
+++ b/backend/ASTU-backend-group-2/repository/chat_repository.go
@@ -4,29 +4,31 @@ import (
 	"context"
 
 	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/domain/entities"
+	custom_error "github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/domain/errors"
 	mongopagination "github.com/gobeam/mongo-go-pagination"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type chatRepository struct {
-	database   mongo.Database
-	collection string
+	database       mongo.Database
+	collectionName string
 }
 
 func NewChatRepository(db mongo.Database, collection string) entities.ChatRepository {
 	return &chatRepository{
-		database:   db,
-		collection: collection,
+		database:       db,
+		collectionName: collection,
 	}
 }
 
 func (cr *chatRepository) CreateChat(c context.Context, chat entities.Chat) (entities.Chat, error) {
-	collection := cr.database.Collection(cr.collection)
+	collection := cr.database.Collection(cr.collectionName)
 	res, err := collection.InsertOne(c, chat)
 	if err != nil {
-		return entities.Chat{}, err
+		return entities.Chat{}, custom_error.ErrCreatingChat
 	}
 
 	chat.ID = res.InsertedID.(primitive.ObjectID)
@@ -34,26 +36,22 @@ func (cr *chatRepository) CreateChat(c context.Context, chat entities.Chat) (ent
 	return chat, nil
 }
 
-func (cr *chatRepository) GetChat(c context.Context, chatID string) (entities.Chat, error) {
-	id, err := primitive.ObjectIDFromHex(chatID)
-	if err != nil {
-		return entities.Chat{}, err
-	}
+func (cr *chatRepository) GetChat(c context.Context, chatID primitive.ObjectID) (entities.Chat, error) {
 
-	collection := cr.database.Collection(cr.collection)
-	filter := bson.M{"_id": id}
+	collection := cr.database.Collection(cr.collectionName)
+	filter := bson.M{"_id": chatID}
 	var dbChat entities.Chat
 	if err := collection.FindOne(c, filter).Decode(&dbChat); err == mongo.ErrNoDocuments {
-		return entities.Chat{}, err
+		return entities.Chat{}, custom_error.ErrChatNotFound
 	} else if err != nil {
-		return entities.Chat{}, err
+		return entities.Chat{}, custom_error.ErrChatNotFound
 	}
 
 	return dbChat, nil
 }
 
-func (cr *chatRepository) GetChats(c context.Context, userID string, limit int64, page int64) ([]entities.Chat, mongopagination.PaginationData, error) {
-	collection := cr.database.Collection(cr.collection)
+func (cr *chatRepository) GetChats(c context.Context, userID primitive.ObjectID, limit int64, page int64) (*[]entities.Chat, mongopagination.PaginationData, error) {
+	collection := cr.database.Collection(cr.collectionName)
 
 	filter := bson.M{"user_id": userID}
 
@@ -62,27 +60,22 @@ func (cr *chatRepository) GetChats(c context.Context, userID string, limit int64
 	paginatedData, err := mongopagination.New(collection).Context(c).Limit(limit).Page(page).Filter(filter).Decode(&chats).Find()
 
 	if err != nil {
-		return nil, mongopagination.PaginationData{}, err
+		return nil, mongopagination.PaginationData{}, custom_error.ErrFilteringChats
 	}
 
-	return chats, paginatedData.Pagination, nil
+	return &chats, paginatedData.Pagination, nil
 }
 
-func (cr *chatRepository) CreateMessage(c context.Context, chatID string, body entities.Message) error {
+func (cr *chatRepository) CreateMessage(c context.Context, chatID primitive.ObjectID, body entities.Message) error {
 
-	id, err := primitive.ObjectIDFromHex(chatID)
-	if err != nil {
-		return err
-	}
-
-	collection := cr.database.Collection(cr.collection)
+	collection := cr.database.Collection(cr.collectionName)
 	query := bson.M{
 		"$push": bson.M{"history": body},
 	}
 
-	_, err = collection.UpdateByID(c, id, query)
+	_, err := collection.UpdateByID(c, chatID, query)
 	if err == mongo.ErrNoDocuments {
-		return err
+		return custom_error.ErrChatNotFound
 	}
 
 	if err != nil {
@@ -92,23 +85,37 @@ func (cr *chatRepository) CreateMessage(c context.Context, chatID string, body e
 	return nil
 }
 
-func (cr *chatRepository) DeleteChat(c context.Context, chatID string) error {
-	id, err := primitive.ObjectIDFromHex(chatID)
-	if err != nil {
-		return err
-	}
+func (cr *chatRepository) DeleteChat(c context.Context, chatID primitive.ObjectID) error {
 
-	collection := cr.database.Collection(cr.collection)
-	filter := bson.M{"_id": id}
+	collection := cr.database.Collection(cr.collectionName)
+	filter := bson.M{"_id": chatID}
 
 	deleteResult, err := collection.DeleteOne(c, filter)
-	if err != nil {
-		return err
-	}
-
-	if deleteResult.DeletedCount == 0 {
-		return err
+	if err != nil || deleteResult.DeletedCount == 0 {
+		return custom_error.ErrChatNotFound
 	}
 
 	return nil
+}
+
+func (cr *chatRepository) UpdateChat(ctx context.Context, chatID primitive.ObjectID, updatedChat entities.Chat) (entities.Chat, error) {
+	collection := cr.database.Collection(cr.collectionName)
+	filter := bson.M{"_id": chatID}
+	update := bson.M{
+		"$set": bson.M{
+			"user_id":    updatedChat.UserID,
+			"title":      updatedChat.Title,
+			"messages":   updatedChat.Messages,
+			"created_at": updatedChat.CreatedAt,
+			"updated_at": updatedChat.UpdatedAt,
+		},
+	}
+
+	_, err :=
+		collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return entities.Chat{}, custom_error.ErrChatNotFound
+	}
+
+	return updatedChat, nil
 }

--- a/backend/ASTU-backend-group-2/repository/reset_password_repository.go
+++ b/backend/ASTU-backend-group-2/repository/reset_password_repository.go
@@ -12,21 +12,21 @@ import (
 )
 
 type resetPasswordRepository struct {
-	database        mongo.Database
-	usersCollection string
-	resetCollection string
+	database            mongo.Database
+	usersCollectionName string
+	resetCollectionName string
 }
 
 func NewResetPasswordRepository(db mongo.Database, userCollection string, resetCollection string) entities.ResetPasswordRepository {
 	return &resetPasswordRepository{
-		database:        db,
-		usersCollection: userCollection,
-		resetCollection: resetCollection,
+		database:            db,
+		usersCollectionName: userCollection,
+		resetCollectionName: resetCollection,
 	}
 }
 
 func (rp *resetPasswordRepository) GetUserByEmail(c context.Context, email string) (*entities.User, error) {
-	collection := rp.database.Collection(rp.usersCollection)
+	collection := rp.database.Collection(rp.usersCollectionName)
 	var user entities.User
 	err := collection.FindOne(c, bson.M{"email": email}).Decode(&user)
 	if err != nil {
@@ -36,7 +36,7 @@ func (rp *resetPasswordRepository) GetUserByEmail(c context.Context, email strin
 }
 func (rp *resetPasswordRepository) ResetPassword(c context.Context, userID string, resetPassword *entities.ResetPasswordRequest) error {
 
-	collection := rp.database.Collection(rp.usersCollection)
+	collection := rp.database.Collection(rp.usersCollectionName)
 	ObjID, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return custom_error.ErrInvalidID
@@ -52,7 +52,7 @@ func (rp *resetPasswordRepository) ResetPassword(c context.Context, userID strin
 }
 
 func (rp *resetPasswordRepository) SaveOtp(c context.Context, otp *entities.OtpSave) error {
-	collection := rp.database.Collection(rp.resetCollection)
+	collection := rp.database.Collection(rp.resetCollectionName)
 
 	_, err := collection.InsertOne(c, otp)
 
@@ -65,7 +65,7 @@ func (rp *resetPasswordRepository) SaveOtp(c context.Context, otp *entities.OtpS
 
 func (rp *resetPasswordRepository) GetOTPByEmail(c context.Context, email string) (*entities.OtpSave, error) {
 
-	collection := rp.database.Collection(rp.resetCollection)
+	collection := rp.database.Collection(rp.resetCollectionName)
 	var otp entities.OtpSave
 
 	err := collection.FindOne(c, bson.M{"email": email}).Decode(&otp)
@@ -83,7 +83,7 @@ func (rp *resetPasswordRepository) GetOTPByEmail(c context.Context, email string
 
 func (rp *resetPasswordRepository) DeleteOtp(c context.Context, email string) error {
 
-	collection := rp.database.Collection(rp.resetCollection)
+	collection := rp.database.Collection(rp.resetCollectionName)
 
 	_, err := collection.DeleteOne(c, bson.M{"email": email})
 

--- a/backend/ASTU-backend-group-2/repository/user_repository.go
+++ b/backend/ASTU-backend-group-2/repository/user_repository.go
@@ -15,19 +15,19 @@ import (
 )
 
 type userRepository struct {
-	database   mongo.Database
-	collection string
+	database       mongo.Database
+	collectionName string
 }
 
 func NewUserRepository(db mongo.Database, collection string) entities.UserRepository {
 	return &userRepository{
-		database:   db,
-		collection: collection,
+		database:       db,
+		collectionName: collection,
 	}
 }
 
 func (ur *userRepository) CreateUser(c context.Context, user *entities.User) (*entities.User, error) {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 
 	_, err := collection.InsertOne(c, user)
 	if err != nil {
@@ -37,7 +37,7 @@ func (ur *userRepository) CreateUser(c context.Context, user *entities.User) (*e
 	return user, err
 }
 func (ur *userRepository) IsOwner(c context.Context) (bool, error) {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	count, err := collection.CountDocuments(context.TODO(), bson.M{})
 	if err != nil {
 		return false, custom_error.ErrErrorCreatingUser
@@ -45,7 +45,7 @@ func (ur *userRepository) IsOwner(c context.Context) (bool, error) {
 	return count == 0, nil
 }
 func (ur *userRepository) UpdateRefreshToken(c context.Context, userID string, refreshToken string) error {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	id, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return custom_error.ErrInvalidID
@@ -56,7 +56,7 @@ func (ur *userRepository) UpdateRefreshToken(c context.Context, userID string, r
 }
 
 func (ur *userRepository) UpdateLastLogin(c context.Context, userID string) error {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	id, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return custom_error.ErrInvalidID
@@ -72,7 +72,7 @@ func (ur *userRepository) UpdateLastLogin(c context.Context, userID string) erro
 }
 
 func (ur *userRepository) GetUserById(c context.Context, userId string) (*entities.User, error) {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	var user entities.User
 
 	id, err := primitive.ObjectIDFromHex(userId)
@@ -92,7 +92,7 @@ func (ur *userRepository) GetUserById(c context.Context, userId string) (*entiti
 }
 
 func (ur *userRepository) GetUserByEmail(c context.Context, email string) (*entities.User, error) {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	var user entities.User
 	err := collection.FindOne(c, bson.M{"email": email}).Decode(&user)
 	if err != nil {
@@ -102,7 +102,7 @@ func (ur *userRepository) GetUserByEmail(c context.Context, email string) (*enti
 }
 
 func (ur *userRepository) GetUsers(c context.Context, filter bson.M, userFilter entities.UserFilter) (*[]entities.User, mongopagination.PaginationData, error) {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 
 	projectQuery := bson.M{"$project": bson.M{
 		"password":     0,
@@ -132,7 +132,7 @@ func (ur *userRepository) GetUsers(c context.Context, filter bson.M, userFilter 
 }
 
 func (ur *userRepository) RevokeRefreshToken(c context.Context, userID, refreshToken string) error {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	objID, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return errors.New("object id invalid")
@@ -150,7 +150,7 @@ func (ur *userRepository) RevokeRefreshToken(c context.Context, userID, refreshT
 }
 
 func (ur *userRepository) UpdateUser(c context.Context, userID string, updatedUser *entities.UserUpdate) (*entities.User, error) {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	id, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return nil, custom_error.ErrInvalidID
@@ -170,7 +170,7 @@ func (ur *userRepository) UpdateUser(c context.Context, userID string, updatedUs
 }
 
 func (ur *userRepository) ActivateUser(c context.Context, userID string) (*entities.User, error) {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	id, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return nil, custom_error.ErrInvalidID
@@ -191,7 +191,7 @@ func (ur *userRepository) ActivateUser(c context.Context, userID string) (*entit
 }
 
 func (ur *userRepository) DeleteUser(c context.Context, userID string) error {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	id, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return custom_error.ErrInvalidID
@@ -210,7 +210,7 @@ func (ur *userRepository) DeleteUser(c context.Context, userID string) error {
 	return nil
 }
 func (ur *userRepository) IsUserActive(c context.Context, userID string) (bool, error) {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	var user entities.User
 	err := collection.FindOne(c, bson.M{"_id": userID}).Decode(&user)
 	if err != nil {
@@ -220,7 +220,7 @@ func (ur *userRepository) IsUserActive(c context.Context, userID string) (bool, 
 
 }
 func (ur *userRepository) ResetUserPassword(c context.Context, userID string, resetPassword *entities.ResetPasswordRequest) error {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	ObjID, err := primitive.ObjectIDFromHex(userID)
 
 	if err != nil {
@@ -236,7 +236,7 @@ func (ur *userRepository) ResetUserPassword(c context.Context, userID string, re
 	return nil
 }
 func (ur *userRepository) UpdateUserPassword(c context.Context, userID string, updatePassword *entities.UpdatePassword) error {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	ObjID, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return custom_error.ErrInvalidID
@@ -252,7 +252,7 @@ func (ur *userRepository) UpdateUserPassword(c context.Context, userID string, u
 	return nil
 }
 func (ur *userRepository) PromoteUserToAdmin(c context.Context, userID string) error {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	ObjID, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return custom_error.ErrInvalidID
@@ -267,7 +267,7 @@ func (ur *userRepository) PromoteUserToAdmin(c context.Context, userID string) e
 	return nil
 }
 func (ur *userRepository) DemoteAdminToUser(c context.Context, userID string) error {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	ObjID, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return custom_error.ErrInvalidID
@@ -282,7 +282,7 @@ func (ur *userRepository) DemoteAdminToUser(c context.Context, userID string) er
 	return nil
 }
 func (ur *userRepository) UpdateProfilePicture(c context.Context, userID string, filename string) error {
-	collection := ur.database.Collection(ur.collection)
+	collection := ur.database.Collection(ur.collectionName)
 	ObjID, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		return custom_error.ErrInvalidID
@@ -291,5 +291,43 @@ func (ur *userRepository) UpdateProfilePicture(c context.Context, userID string,
 	if res.ModifiedCount < 1 {
 		return custom_error.ErrUserNotFound
 	}
+	return nil
+}
+
+func (ur *userRepository) GetInactiveUsersForReactivation(c context.Context, emailTreshold primitive.DateTime, deleteTreshold primitive.DateTime) (*[]entities.User, error) {
+	collection := ur.database.Collection(ur.collectionName)
+
+	filter := bson.M{
+		"is_active":  false,
+		"created_at": bson.M{"$lt": emailTreshold, "$gte": deleteTreshold},
+	}
+
+	// Users who haven't activated their account within `emailTreshold` days
+	var users []entities.User
+	cur, err := collection.Find(c, filter)
+	if err != nil {
+		return &[]entities.User{}, custom_error.ErrErrorSendingReminderEmail
+	}
+	err = cur.All(c, &users)
+	if err != nil {
+		return &[]entities.User{}, custom_error.ErrErrorSendingReminderEmail
+	}
+
+	return &users, nil
+}
+
+func (ur *userRepository) DeleteInActiveUser(c context.Context, deleteTreshold primitive.DateTime) error {
+	collection := ur.database.Collection(ur.collectionName)
+
+	filter := bson.M{
+		"is_active":  false,
+		"created_at": bson.M{"$lt": deleteTreshold},
+	}
+
+	_, err := collection.DeleteMany(c, filter)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/backend/ASTU-backend-group-2/usecase/user_usecase.go
+++ b/backend/ASTU-backend-group-2/usecase/user_usecase.go
@@ -6,14 +6,18 @@ import (
 	"log"
 	"time"
 
+	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/bootstrap"
 	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/domain/entities"
+	"github.com/a2sv-g5-project-phase-starter-project/backend/ASTU-backend-group-2/internal/emailutil"
 	mongopagination "github.com/gobeam/mongo-go-pagination"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type userUsecase struct {
 	userRepository entities.UserRepository
 	contextTimeout time.Duration
+	Env            *bootstrap.Env
 }
 
 func NewUserUsecase(userRepository entities.UserRepository, timeout time.Duration) entities.UserUsecase {
@@ -192,4 +196,63 @@ func UserFilterOption(filter entities.UserFilter) bson.M {
 	log.Println(query)
 	return query
 
+}
+
+func (uu *userUsecase) SendReminderEmail(c context.Context) error {
+	ctx, cancel := context.WithTimeout(c, time.Second*10)
+	defer cancel()
+
+	emailTreshold := primitive.NewDateTimeFromTime(time.Now().AddDate(0, 0, -3))
+	deleteTreshold := primitive.NewDateTimeFromTime(time.Now().AddDate(0, 0, -10))
+
+	users, err := uu.userRepository.GetInactiveUsersForReactivation(ctx, emailTreshold, deleteTreshold)
+
+	if err != nil {
+		return err
+	}
+
+	for _, user := range *users {
+		// Send activation email
+		err := emailutil.SendVerificationEmail(user.Email, user.VerToken, uu.Env)
+		if err != nil {
+			log.Println("Error sending reminder email to user:", user.Email)
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (uu *userUsecase) DeleteInActiveUsers(c context.Context) error {
+	ctx, cancel := context.WithTimeout(c, time.Second*10)
+	defer cancel()
+
+	deleteTreshold := primitive.NewDateTimeFromTime(time.Now().AddDate(0, 0, -10))
+
+	err := uu.userRepository.DeleteInActiveUser(ctx, deleteTreshold)
+
+	return err
+}
+
+// Schedule the process to send reminders and delete inactive users
+func (uu *userUsecase) ScheduleDeleteAndReminderForInActiveUser(c context.Context) {
+	ctx, cancel := context.WithTimeout(c, time.Second*10)
+	defer cancel()
+
+	ticker := time.NewTicker(24 * time.Hour)
+	go func() {
+		for range ticker.C {
+			// Send reminder emails to users who haven't activated within 3 days
+			err := uu.SendReminderEmail(ctx)
+			if err != nil {
+				log.Println("Error sending reminder emails:", err)
+			}
+
+			// Delete users who have been inactive for more than 7 days
+			err = uu.DeleteInActiveUsers(c)
+			if err != nil {
+				log.Println("Error deleting inactive users:", err)
+			}
+		}
+	}()
 }


### PR DESCRIPTION
Refactor the error handling in the `ChatController` and `ResetPasswordController` to use the `c.Error` method instead of returning an error response with JSON. This improves consistency and simplifies the error handling code in these controllers.